### PR TITLE
Had issues applying helm charts.

### DIFF
--- a/cluster-agent/templates/deployment.yaml
+++ b/cluster-agent/templates/deployment.yaml
@@ -13,8 +13,8 @@ spec:
         chart: {{ template "cluster-agent.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-    restartPolicy: Always
     spec: 
+      restartPolicy: Always
       containers: 
         - env: 
 {{- if .Values.controller.controllerKey }}
@@ -48,9 +48,9 @@ spec:
               protocol: TCP
           resources:
 {{- if .Values.deployment.resources }}
-{{ toYaml .Values.deployment.resources | indent 10 }}
+{{ toYaml .Values.deployment.resources | indent 12 }}
 {{- else if .Values.resources }}
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 12 }}
 {{- end }}
           volumeMounts: 
             - mountPath: /opt/appdynamics/config/

--- a/cluster-agent/templates/rbac.yaml
+++ b/cluster-agent/templates/rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
-namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Hi,

When I tried to apply this chart to a k8s cluster (v1.12.7), I hit a few snags:

```
error: error validating "generated/aws-htl-prod/cloud-native/appdynamics-cluster-agent.yaml": error validating data: ValidationError(ServiceAccount): unknown field "namespace" in io.k8s.api.core.v1.ServiceAccount
```

```
error: error validating "generated/aws-htl-prod/cloud-native/appdynamics-cluster-agent.yaml": error validating data: [ValidationError(Deployment.spec.template): unknown field "restartPolicy" in io.k8s.api.core.v1.PodTemplateSpec
```

```
error:  ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "limits" in io.k8s.api.core.v1.Container, ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "requests" in io.k8s.api.core.v1.Container]
```
Moving things around in the chart-generated files allowed me to apply changes with kubectl.

Apologies if I'm off track.